### PR TITLE
fix: Load .env dynamically to ensure token expiry changes apply immediately

### DIFF
--- a/hub/core/security.py
+++ b/hub/core/security.py
@@ -13,6 +13,9 @@ from shared.database import AsyncSessionLocal
 from shared.models import PersonalAccessTokenORM, UserORM
 from shared.secret_store import load_or_create_secret
 from shared.time_utils import now_in_app_timezone_naive
+from dotenv import load_dotenv
+
+load_dotenv()
 
 pwd_context = CryptContext(
     schemes=["pbkdf2_sha256", "bcrypt_sha256", "bcrypt"],


### PR DESCRIPTION
Resolves #15

### Root Cause
Previously, `ACCESS_TOKEN_EXPIRE_MINUTES` was read exclusively from the OS environment variables injected by Docker Compose at container start time. If a developer modified `.env` and simply restarted the Python server via `uvicorn --reload` or manually ran `uv run` inside the dev container, the Python process would NOT pick up the updated environment variable and would fall back to the default 120 minutes. This led to frequent token expiration (2 hours) despite the user correctly configuring a longer validity in `.env`.

### Fix
Added `python-dotenv` explicitly in `hub/core/security.py` to load the `.env` file directly at runtime. Now, whenever the server restarts or reloads, it correctly parses any updated settings from `.env`.