### PR TITLE
fix: remove unused err variable in SettingsDialog.vue

### DIFF
--- a/web/src/components/SettingsDialog.vue
+++ b/web/src/components/SettingsDialog.vue
@@ -116,7 +116,7 @@ function handleExportDatabase() {
       window.URL.revokeObjectURL(downloadUrl)
       a.remove()
     })
-    .catch(err => {
+    .catch(() => {
       toast({ title: 'Export failed', variant: 'destructive' })
     })
 }


### PR DESCRIPTION
Resolves GitHub Actions build failure caused by TS6133 unused variable error.