### PR TITLE
fix: prevent InvalidCachedStatementError after database import

### DIFF
--- a/hub/api/routers/admin.py
+++ b/hub/api/routers/admin.py
@@ -18,7 +18,7 @@ from hub.api.schemas import (
 from hub.core.billing import get_billing_state, save_billing_config
 from hub.core import model_settings
 from hub.core.security import require_admin
-from shared.database import AsyncSessionLocal, DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME
+from shared.database import AsyncSessionLocal, DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME, engine
 from shared.models import InvitationCodeORM, UserORM, SystemConfigORM
 
 router = APIRouter(prefix="/api/admin", tags=["Admin"])
@@ -166,21 +166,29 @@ async def import_database(file: UploadFile = File(...), current_user=Depends(req
     db_url = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     fd, path = tempfile.mkstemp(suffix=".dump")
     os.close(fd)
-    
+
     try:
         content = await file.read()
         with open(path, "wb") as f:
             f.write(content)
-            
-        subprocess.run(
+
+        result = subprocess.run(
             ["pg_restore", "--clean", "--if-exists", "-O", "-x", "-d", db_url, path],
-            check=True,
             capture_output=True,
         )
-    except subprocess.CalledProcessError as e:
-        raise HTTPException(status_code=500, detail=f"Import failed: {e.stderr.decode('utf-8', errors='replace')}")
+
+        # pg_restore exit codes: 0=success, 1=warnings (acceptable), 2+=errors
+        if result.returncode >= 2:
+            stderr_text = result.stderr.decode("utf-8", errors="replace")
+            raise HTTPException(status_code=500, detail=f"Import failed: {stderr_text}")
+
+        # pg_restore modifies the schema; invalidate all cached prepared
+        # statements in the hub's connection pool so the next request creates
+        # fresh connections instead of hitting InvalidCachedStatementError.
+        await engine.dispose()
+
     finally:
         if os.path.exists(path):
             os.remove(path)
-            
+
     return {"status": "success"}


### PR DESCRIPTION
## Summary
修复数据库导入后 Hub 连接池中的 prepared statement 缓存失效问题，避免后续请求报 `InvalidCachedStatementError`。

## 问题分析
`pg_restore --clean` 会 drop/recreate 表和约束，导致连接池中已缓存的 prepared statement 失效。Import 后第一次请求必定失败，需要多次请求才能通过 asyncpg 的自愈机制刷新缓存。

## 修复方案
1. **强制刷新连接池**：Import 成功后调用 `engine.dispose()`，丢弃所有现有连接，下次请求创建全新连接
2. **改进错误处理**：`pg_restore` 退出码 1 表示警告（可接受），只有 >= 2 才是真实错误

## Changes
- `hub/api/routers/admin.py`: import engine, dispose connection pool after import, improve pg_restore exit code handling

## Test plan
- [x] 导出数据库后删除数据源再导入，Import API 不再返回 500
- [x] 导入后立即访问 /api/items 不再报 InvalidCachedStatementError
- [x] 数据正常显示，无需等待自愈