### PR TITLE
fix: resolve RAG queue backlog by adding worker concurrency and crash recovery

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
       RUN_DB_MIGRATIONS: "0"
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-120}
       JWT_ALGORITHM: ${JWT_ALGORITHM:-HS256}
-    command: ["uv", "run", "taskiq", "worker", "worker.main:broker"]
+    command: ["uv", "run", "taskiq", "worker", "-p", "4", "worker.main:broker"]
     depends_on:
       postgres:
         condition: service_healthy

--- a/worker/maintenance.py
+++ b/worker/maintenance.py
@@ -1,4 +1,4 @@
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from shared.database import AsyncSessionLocal
 from shared.entities import AIProcessingStatus, UniversalItem
 from shared.models import ConfigORM, ItemORM, PluginRegistryORM, UserItemStateORM, SystemConfigORM
@@ -273,12 +273,34 @@ async def system_ttl_cleanup_task():
     task_name="trigger_ai_sweep",
     schedule=[{"cron": "*/5 * * * *"}],
 )
-async def trigger_ai_sweep_task(limit: int = 20):
+async def trigger_ai_sweep_task(limit: int = 100):
     if await _is_scheduler_paused():
         worker_log.info("⏸️ Scheduler is paused by developer settings. Skipping AI sweep.")
         return
 
     worker_log.info("🧠 AI sweep started. Looking for pending lightweight items.")
+
+    # 恢复卡在 processing 状态超过 30 分钟的项（崩溃恢复机制）
+    timeout_threshold = now_in_app_timezone_naive() - timedelta(minutes=30)
+    async with AsyncSessionLocal() as session:
+        recovery_result = await session.execute(
+            update(ItemORM)
+            .where(
+                ItemORM.ai_processing_status == AIProcessingStatus.processing.value,
+                ItemORM.updated_at < timeout_threshold,
+            )
+            .values(
+                ai_processing_status=AIProcessingStatus.pending_ai.value,
+                updated_at=now_in_app_timezone_naive(),
+            )
+        )
+        recovered_count = recovery_result.rowcount
+        if recovered_count > 0:
+            await session.commit()
+            worker_log.info(f"🔄 Recovered {recovered_count} items stuck in processing status.")
+        else:
+            await session.rollback()
+
     async with AsyncSessionLocal() as session:
         result = await session.execute(
             select(ItemORM)


### PR DESCRIPTION
## Summary
修复 RAG 队列积压问题，通过增加 worker 并发、提升 scheduler 批量限制、添加崩溃恢复机制来解决。

## Changes

### 1. Worker 并发配置 (docker-compose.yaml)
- 添加 `-p 4` 参数到 taskiq worker 命令
- 启用 4 个并行 worker 进程同时处理任务
- 之前默认单进程，导致处理速度过慢

### 2. 提升 Scheduler 批量限制 (worker/maintenance.py)
- 将 `trigger_ai_sweep_task` 的批量限制从 20 提升到 100
- 允许 scheduler 每 5 分钟调度更多 pending 项
- 减少处理大批量任务（如 300 个 GitHub 仓库）所需的时间

### 3. 添加 Processing 超时恢复 (worker/maintenance.py)
- 恢复卡在 `processing` 状态超过 30 分钟的项
- 将它们重置为 `pending_ai` 以便重新处理
- 优雅处理 worker 崩溃和任务失败
- 类似 video lock 机制，但适用于所有任务类型

## Impact

- 300 个 GitHub 仓库之前一直卡在 99 个积压项，现在可以正常处理
- Worker 可以并行处理 4 个任务而不是 1 个
- Scheduler 每个周期调度 100 个项而不是 20 个
- 卡住的项在 30 分钟后自动恢复

## Test plan
- [x] 验证 worker 启动时有 4 个进程
- [x] 验证 scheduler 每 5 分钟调度最多 100 个 pending 项
- [ ] 手动将某些项设置为 processing 状态并等待 30 分钟，验证它们被重置为 pending_ai
- [ ] 监控 RAG 积压数是否逐渐减少到 0

Closes #24