### PR TITLE
fix: resolve AI summary language mismatch (Closes #31)

### DIFF
--- a/hub/api/routers/auth.py
+++ b/hub/api/routers/auth.py
@@ -247,3 +247,40 @@ async def delete_pat(pat_id: str, current_user=Depends(get_current_user)):
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="令牌不存在")
             await session.delete(pat)
     return {"status": "success"}
+
+
+class UpdateLocaleRequest(BaseModel):
+    locale: str
+
+
+class UserLocaleResponse(BaseModel):
+    preferred_locale: str
+
+
+@router.get("/me", response_model=UserLocaleResponse)
+async def get_current_user_info(current_user=Depends(get_current_user)):
+    """Get current user's preferred locale"""
+    async with AsyncSessionLocal() as session:
+        user = await session.get(UserORM, current_user["id"])
+        if not user:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="用户不存在")
+        return UserLocaleResponse(preferred_locale=user.preferred_locale)
+
+
+@router.put("/locale")
+async def update_locale(
+    payload: UpdateLocaleRequest,
+    current_user=Depends(get_current_user),
+):
+    """Update current user's preferred locale"""
+    # Normalize locale to zh-CN or en
+    normalized_locale = "zh-CN" if payload.locale.startswith("zh") else "en"
+
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            user = await session.get(UserORM, current_user["id"])
+            if not user:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="用户不存在")
+            user.preferred_locale = normalized_locale
+
+    return {"status": "success", "preferred_locale": normalized_locale}

--- a/hub/api/routers/plugins.py
+++ b/hub/api/routers/plugins.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
 from typing import Dict, Any, List
 import shutil
 import os
@@ -470,15 +470,18 @@ async def save_plugin_config(plugin_id: str, config: Dict[str, Any], current_use
     return {"status": "success", "message": f"{plugin.manifest.get('name')} configuration was saved."}
 
 @router.post("/{plugin_id}/sync")
-async def trigger_plugin_sync(plugin_id: str, current_user=Depends(get_current_user)):
+async def trigger_plugin_sync(plugin_id: str, request: Request, current_user=Depends(get_current_user)):
     """Trigger a manual sync for a plugin."""
     plugin = plugin_manager.get_plugin(plugin_id)
     if not plugin:
         raise HTTPException(status_code=404, detail=f"Plugin was not found: {plugin_id}")
-        
+
+    # Extract preferred locale from Accept-Language header
+    preferred_locale = request.headers.get("Accept-Language", "zh-CN")
+
     # 异步触发，取代之前的 sync_github_stars_task
-    task = await run_plugin_pipeline_task.kiq(plugin_id, None, current_user["id"], "manual")
-    
+    task = await run_plugin_pipeline_task.kiq(plugin_id, None, current_user["id"], "manual", preferred_locale)
+
     return {
         "status": "accepted",
         "task_id": task.task_id if task else None,

--- a/migrations/versions/cdb49f938e99_add_preferred_locale_to_users.py
+++ b/migrations/versions/cdb49f938e99_add_preferred_locale_to_users.py
@@ -1,0 +1,28 @@
+"""add_preferred_locale_to_users
+
+Revision ID: cdb49f938e99
+Revises: 897b9780e62a
+Create Date: 2026-05-25 01:21:44.791401
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'cdb49f938e99'
+down_revision: Union[str, Sequence[str], None] = '897b9780e62a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('users', sa.Column('preferred_locale', sa.String(), server_default='zh-CN', nullable=False))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'preferred_locale')

--- a/shared/models.py
+++ b/shared/models.py
@@ -107,6 +107,7 @@ class UserORM(Base):
     username: Mapped[str] = mapped_column(String, unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(String)
     role: Mapped[str] = mapped_column(String, default="admin")
+    preferred_locale: Mapped[str] = mapped_column(String, default="zh-CN", server_default="zh-CN")
 
 
 class PersonalAccessTokenORM(Base):

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -13,6 +13,7 @@ import SettingsDialog from '@/components/SettingsDialog.vue'
 import PluginSettingsDialog from '@/components/PluginSettingsDialog.vue'
 import { SUPPORTED_LOCALES, getAppLocale, setAppLocale } from '@/i18n'
 import {
+  apiClient,
   clearNotifications,
   clearStoredToken,
   getNotifications,
@@ -162,10 +163,20 @@ async function navigateTo(path: string, disabled?: boolean) {
   await router.push(path)
 }
 
-onMounted(() => {
+onMounted(async () => {
   const savedSidebarState = window.localStorage.getItem(SIDEBAR_STATE_KEY)
   if (savedSidebarState === 'false') {
     sidebarOpen.value = false
+  }
+
+  // Sync locale from backend on mount (if user is logged in)
+  try {
+    const { data } = await apiClient.get('/api/auth/me')
+    if (data.preferred_locale && data.preferred_locale !== currentLocale.value) {
+      currentLocale.value = data.preferred_locale
+    }
+  } catch {
+    // User not logged in or API error, use localStorage locale
   }
 
   void loadNotifications()
@@ -197,6 +208,10 @@ watch(currentLocale, (value) => {
   if (locale.value !== nextLocale) {
     locale.value = nextLocale
   }
+  // Sync locale preference to backend
+  apiClient.put('/api/auth/locale', { locale: nextLocale }).catch((err) => {
+    console.error('Failed to sync locale to backend:', err)
+  })
 })
 
 watch(locale, (value) => {

--- a/worker/maintenance.py
+++ b/worker/maintenance.py
@@ -1,7 +1,7 @@
 from sqlalchemy import delete, select, update
 from shared.database import AsyncSessionLocal
 from shared.entities import AIProcessingStatus, UniversalItem
-from shared.models import ConfigORM, ItemORM, PluginRegistryORM, UserItemStateORM, SystemConfigORM
+from shared.models import ConfigORM, ItemORM, PluginRegistryORM, UserItemStateORM, SystemConfigORM, UserORM
 from datetime import datetime, timedelta
 from worker.broker import broker
 from shared.logger import worker_log
@@ -25,6 +25,17 @@ async def _get_plugin_setting(plugin_id: str, key: str, fallback: str, user_id: 
     if default in (None, ""):
         return fallback
     return str(default).lower() if isinstance(default, bool) else str(default)
+
+
+async def _get_user_preferred_locale(user_id: str | None) -> str | None:
+    """Get the preferred locale for a user from the database."""
+    if not user_id:
+        return None
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(UserORM.preferred_locale).where(UserORM.id == user_id)
+        )
+        return result.scalar_one_or_none()
 
 
 async def _resolve_auto_sync_user_id(plugin_id: str) -> str | None:
@@ -157,13 +168,14 @@ async def system_heartbeat_task():
                         f"💓 [{plugin_id}] Auto-sync skipped because no user has all required credentials bound and readable."
                     )
                     continue
+                preferred_locale = await _get_user_preferred_locale(user_id)
                 worker_log.info(
-                    f"💓 [{plugin_id}] Auto-sync conditions met. Dispatching incremental sync task for user {user_id}."
+                    f"💓 [{plugin_id}] Auto-sync conditions met. Dispatching incremental sync task for user {user_id} (locale={preferred_locale})."
                 )
-                await run_plugin_pipeline_task.kiq(plugin_id, None, user_id, "auto")
+                await run_plugin_pipeline_task.kiq(plugin_id, None, user_id, "auto", preferred_locale)
             else:
                 worker_log.info(f"💓 [{plugin_id}] Auto-sync conditions met. Dispatching incremental sync task.")
-                await run_plugin_pipeline_task.kiq(plugin_id, None, None, "auto")
+                await run_plugin_pipeline_task.kiq(plugin_id, None, None, "auto", None)
             triggered_count += 1
         else:
             worker_log.info(

--- a/worker/plugins/pipeline.py
+++ b/worker/plugins/pipeline.py
@@ -103,6 +103,7 @@ async def run_plugin_pipeline_task(
     limit: int = None,
     user_id: str | None = None,
     sync_mode: str = "manual",
+    preferred_locale: str | None = None,
 ):
     """
     Run the generic sync pipeline for a specific plugin.
@@ -206,6 +207,9 @@ async def run_plugin_pipeline_task(
                 final_metadata = normalized.get("metadata_extra", {})
                 final_metadata.update(metadata_extra)
                 final_metadata["has_long_summary"] = False
+
+                if preferred_locale:
+                    final_metadata["preferred_locale"] = preferred_locale
 
                 if incremental_ai_sync:
                     await _store_lightweight_item(


### PR DESCRIPTION
## Summary

修复 AI 摘要语言不匹配问题：即使 UI 设置为中文，AI 生成的摘要仍然是英文。

## Problem

- **现象**: 用户界面设置为中文时，通过插件同步的内容（如 GitHub Stars）生成的 AI 摘要仍然是英文
- **根因**: 插件批量同步任务没有传递 `preferred_locale` 参数到 AI 处理管道
- **影响**: AI 处理管道在读取不到 locale 时默认使用英文，导致所有插件同步内容的摘要都变成英文

## Root Cause Analysis

项目有 3 条路径创建 item 并触发 AI 摘要：

| 路径 | 是否传递 locale | 结果 |
|------|---------------|------|
| 单条 URL 解析 | ✅ | 摘要语言正确 |
| 本地文件上传 | ✅ | 摘要语言正确 |
| **插件批量同步** | ❌ **缺失** | **摘要永远是英文** |

具体链路：
1. 插件批量同步时，`run_plugin_pipeline_task` 构建 `UniversalItem` 没有设置 `metadata_extra["preferred_locale"]`
2. Item 进入 AI sweep → ingestion pipeline → `_generate_summary()` 读取 `(item.metadata_extra or {}).get("preferred_locale")` 得到 `None`
3. `normalize_preferred_locale(None)` 返回 `"en"`
4. LLM prompt 中语言指令变为 "write the final answer in English"

## Solution

### 1. 数据库层 - 添加用户语言偏好字段
- 在 `UserORM` 中添加 `preferred_locale` 字段（默认值 `zh-CN`）
- 创建 Alembic 迁移脚本

### 2. 后端 API - 用户语言偏好管理
- `GET /api/auth/me`: 获取当前用户的语言偏好
- `PUT /api/auth/locale`: 更新用户的语言偏好

### 3. 插件同步 - 传递语言偏好
- **手动同步**: 从 `Accept-Language` 请求头读取语言，传递给 `run_plugin_pipeline_task`
- **自动同步**: 从数据库读取用户的 `preferred_locale`，传递给 `run_plugin_pipeline_task`
- **管道处理**: 将语言偏好存入 item 的 `metadata_extra["preferred_locale"]`

### 4. 前端 - 语言切换同步
- 监听语言切换事件，调用 `PUT /api/auth/locale` 同步到后端
- 组件挂载时调用 `GET /api/auth/me` 读取后端存储的语言偏好

## Data Flow

**用户切换语言时：**
```
前端 UI 切换 → localStorage 更新 → 调用 PUT /api/auth/locale → 数据库 users.preferred_locale 更新
```

**插件同步时：**
```
用户点击同步 → 读取 Accept-Language 头 → 传递给 run_plugin_pipeline_task → 存入 item.metadata_extra.preferred_locale → AI 处理时读取并生成对应语言的摘要
```

**自动同步时：**
```
Scheduler 触发 → 从数据库读取 users.preferred_locale → 传递给 run_plugin_pipeline_task → 存入 item.metadata_extra.preferred_locale → AI 处理时读取并生成对应语言的摘要
```

**用户登录/刷新时：**
```
MainLayout 挂载 → 调用 GET /api/auth/me → 读取 preferred_locale → 更新前端语言状态
```

## Changes

### Backend
- `shared/models.py`: Add `preferred_locale` field to `UserORM` (default: `zh-CN`)
- `migrations/versions/cdb49f938e99_add_preferred_locale_to_users.py`: Database migration
- `hub/api/routers/auth.py`: Add `GET /api/auth/me` and `PUT /api/auth/locale` endpoints
- `hub/api/routers/plugins.py`: Extract `Accept-Language` header and pass to sync task
- `worker/plugins/pipeline.py`: Accept and store `preferred_locale` in item metadata
- `worker/maintenance.py`: Read user's `preferred_locale` for auto-sync tasks

### Frontend
- `web/src/layouts/MainLayout.vue`: Sync locale to backend on change and load on mount

## Impact

- ✅ AI summaries will now respect user's UI language preference
- ✅ Both manual and automatic plugin sync will generate summaries in correct language
- ✅ User locale preference persists across sessions and devices
- ✅ Existing items without locale will continue to use default (English)

## Test Plan

- [ ] 用户在前端切换语言后，刷新页面语言保持不变
- [ ] 手动触发插件同步（如 GitHub Stars），生成的 AI 摘要使用用户当前选择的语言
- [ ] 等待自动同步触发，生成的 AI 摘要使用用户存储的语言偏好
- [ ] 用户在不同设备登录，语言偏好保持一致
- [ ] 已存在的 items（没有 locale 信息）继续正常工作

## Related Issues

Closes #31