### PR TITLE
feat: plugin upgrade safety and development guide update

### DIFF
--- a/PEKNO_PLUGIN_GUIDE.md
+++ b/PEKNO_PLUGIN_GUIDE.md
@@ -86,8 +86,34 @@ Required manifest fields:
 
 - `id`: Stable snake_case plugin ID. This becomes the DB key and install directory name.
 - `name`: Human-readable name.
-- `version`: Plugin version.
+- `version`: Plugin version (see Versioning below).
 - `source_type`: Stable item source type written to `items.source_type`.
+
+### Versioning
+
+Plugins must follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
+
+- **MAJOR** (`2.0.0`): Breaking changes — removed settings, renamed `source_type`, changed item ID format.
+- **MINOR** (`1.1.0`): New features — new settings, new hover blocks, new capabilities.
+- **PATCH** (`1.0.1`): Bug fixes — no user-facing behavior changes.
+
+When to bump each segment:
+
+| Change | Bump |
+|--------|------|
+| Fix a bug in `normalize_item` | PATCH |
+| Add `cover_url` to normalized items | PATCH |
+| Add a new `settings_schema` field | MINOR |
+| Rename a `settings_schema` field | MAJOR |
+| Change item ID generation logic | MAJOR |
+| Change `source_type` | MAJOR |
+
+The Pekno framework uses version comparison during plugin upgrade:
+
+- Upgrading to a higher version: logged as `⬆️ Upgrading plugin`.
+- Reinstalling the same version: logged as `🔄 Reinstalling plugin`.
+- Installing a lower version: logged as `⬇️ Downgrading plugin` (warning).
+- The framework automatically backs up the previous version (up to 3 versions retained) under `worker/plugins/third_party/.backup/` before overwriting.
 
 Common optional fields:
 
@@ -308,12 +334,49 @@ Rules:
 - Return the same normalized item shape as `normalize_item()`, or return `_pipeline_raw_data` to let the pipeline call `normalize_item()` and `extract_text_for_ai()`.
 - Raise `ValueError` for invalid URLs or unsupported formats.
 - Use `ctx` when credentials or settings are needed.
+- **Always call the platform API to fetch real content.** Do not return a skeleton item with only URL-derived data. If your plugin has a `_fetch_video_info()`, `_fetch_article()`, or similar helper (used by `get_hover_blocks` or `fetch_data`), reuse it here.
+- **Populate `content_text` with meaningful content** (description, summary, article body) — this is what the AI summarizer uses to generate the short summary. An empty `content_text` produces low-quality AI summaries.
+- **Include all metadata fields** that `normalize_item` would produce (author, cover_url, published_at, etc.). Single-item parsing should produce items indistinguishable from batch sync items.
+- **Wrap API calls in try/except** — if the API call fails, fall back to a minimal item rather than crashing the entire parse task.
 
-Example using `_pipeline_raw_data`:
+Example using `_pipeline_raw_data` with API enrichment:
 
 ```python
 async def parse_single_item(self, url: str, ctx: PluginContext | None = None) -> dict:
-    raw = await fetch_remote_object(url, ctx)
+    item_id = self._extract_id(url)
+    if not item_id:
+        raise ValueError("Invalid URL format")
+
+    raw = {"id_hint": item_id, "link": url, "guid": url}
+
+    # Enrich with real platform data if ctx is available
+    if ctx:
+        try:
+            headers = self._headers(ctx)
+            async with httpx.AsyncClient(timeout=10.0, headers=headers) as client:
+                info = await self._fetch_detail(client, item_id)
+            raw["title"] = info.get("title", item_id)
+            raw["author"] = info.get("author", "")
+            raw["cover_url"] = info.get("cover")
+            raw["content_text"] = info.get("description", "")
+            raw["published_at"] = info.get("published_at")
+        except (httpx.HTTPError, ValueError) as exc:
+            ctx.log.warning(f"Failed to fetch detail for {url}: {exc}")
+            raw["title"] = item_id
+            raw["content_text"] = ""
+
+    normalized = self.normalize_item(raw)
+    normalized["_pipeline_raw_data"] = raw
+    return normalized
+```
+
+**Anti-pattern (do not do this):**
+
+```python
+# BAD: Only extracts an ID from the URL, no real content
+async def parse_single_item(self, url: str, ctx=None) -> dict:
+    vid = self._extract_id(url)
+    raw = {"title": vid, "link": url, "content_text": ""}  # ❌ empty content, no real title
     normalized = self.normalize_item(raw)
     normalized["_pipeline_raw_data"] = raw
     return normalized
@@ -400,6 +463,24 @@ During install:
 - Registry row is inserted or updated.
 - Hub reloads plugins in-process.
 - Worker receives `reload_system_plugins_task`.
+
+### Plugin Upgrade (Cover Install)
+
+When installing a plugin whose `id` already exists, Pekno performs a cover upgrade:
+
+1. **Version comparison**: The framework reads the existing version from the database and compares it with the new version using semantic versioning.
+2. **Automatic backup**: Before overwriting, the old plugin directory is copied to `worker/plugins/third_party/.backup/<plugin_id>_<version>_<timestamp>`. Up to 3 most recent backups are retained per plugin.
+3. **Logging**: Upgrade events are logged with version details:
+   - `⬆️ Upgrading plugin {id}: {old} → {new}` for version increases.
+   - `🔄 Reinstalling plugin {id}` for same-version reinstalls.
+   - `⬇️ Downgrading plugin {id}: {old} → {new}` (warning) for version decreases.
+4. **File replacement**: Old files are removed, new files are moved into place.
+5. **Registry update**: The database record is updated with the new version, name, and module path.
+6. **Hot reload**: Hub and Worker reload the updated plugin without restart.
+
+User configuration (settings, credentials) is stored in the `configs` table and is **not affected** by plugin upgrades. Item data in the `items` table is also preserved.
+
+Plugin authors should ensure backward compatibility when upgrading — changing item ID formats or `source_type` values may orphan existing data.
 
 Manual development flow for built-in plugins:
 

--- a/hub/api/routers/plugins.py
+++ b/hub/api/routers/plugins.py
@@ -18,12 +18,15 @@ from sqlalchemy import select, delete
 from hub.core.security import get_current_user, require_admin
 from shared.api_errors import ApiError
 from shared.utils.path_guard import safe_resolve_path
+from shared.logger import hub_log
 
 router = APIRouter(prefix="/api/plugins", tags=["Plugins"])
 
 # Plugin installation paths
 PLUGIN_INSTALL_DIR = Path("worker/plugins/third_party").resolve()
 TEMP_PREVIEW_DIR = Path(tempfile.gettempdir()) / "pekno_plugins"
+PLUGIN_BACKUP_DIR = PLUGIN_INSTALL_DIR / ".backup"
+MAX_BACKUP_VERSIONS = 3
 
 
 def _ensure_plugin_install_dir() -> None:
@@ -31,6 +34,47 @@ def _ensure_plugin_install_dir() -> None:
     init_file = PLUGIN_INSTALL_DIR / "__init__.py"
     if not init_file.exists():
         init_file.write_text("", encoding="utf-8")
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a version string like '1.2.3' into a tuple for comparison."""
+    try:
+        return tuple(int(x) for x in version.split("."))
+    except (ValueError, AttributeError):
+        return (0,)
+
+
+def _compare_versions(old: str, new: str) -> int:
+    """Compare two version strings. Returns -1 if old < new, 0 if equal, 1 if old > new."""
+    old_parts = _parse_version(old)
+    new_parts = _parse_version(new)
+    if old_parts < new_parts:
+        return -1
+    elif old_parts > new_parts:
+        return 1
+    return 0
+
+
+def _backup_plugin(plugin_id: str, plugin_path: Path, version: str) -> None:
+    """Create a backup of the plugin before upgrade/downgrade."""
+    PLUGIN_BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_name = f"{plugin_id}_{version}_{timestamp}"
+    backup_path = PLUGIN_BACKUP_DIR / backup_name
+
+    shutil.copytree(str(plugin_path), str(backup_path))
+    hub_log.info(f"📦 Created backup: {backup_name}")
+
+    # Keep only MAX_BACKUP_VERSIONS most recent backups for this plugin
+    backups = sorted(
+        [p for p in PLUGIN_BACKUP_DIR.iterdir() if p.name.startswith(f"{plugin_id}_") and p.is_dir()],
+        key=lambda p: p.stat().st_mtime,
+    )
+    while len(backups) > MAX_BACKUP_VERSIONS:
+        oldest = backups.pop(0)
+        shutil.rmtree(oldest)
+        hub_log.info(f"🗑️ Removed old backup: {oldest.name}")
 
 
 async def _get_bound_credentials(plugin_id: str, user_id: str, required_credentials: list[str]) -> list[str]:
@@ -267,13 +311,35 @@ async def confirm_install_plugin(token: str, current_user=Depends(require_admin)
         if not plugin_id:
             raise HTTPException(status_code=400, detail="The plugin manifest is missing an id field.")
 
-        # 2. Move files into the installed plugin directory
+        new_version = manifest.get("version", "1.0.0")
+        old_version = None
+        is_upgrade = False
+
+        # 2. Check for existing installation and backup if upgrading
         target_path = PLUGIN_INSTALL_DIR / plugin_id
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(PluginRegistryORM.version).where(PluginRegistryORM.plugin_id == plugin_id)
+            )
+            existing = result.scalar_one_or_none()
+            if existing:
+                old_version = existing
+                cmp = _compare_versions(old_version, new_version)
+                if cmp < 0:
+                    is_upgrade = True
+                    hub_log.info(f"⬆️ Upgrading plugin {plugin_id}: {old_version} → {new_version}")
+                elif cmp > 0:
+                    hub_log.warning(f"⬇️ Downgrading plugin {plugin_id}: {old_version} → {new_version}")
+                else:
+                    hub_log.info(f"🔄 Reinstalling plugin {plugin_id} (version {new_version} unchanged)")
+
         if target_path.exists():
+            if old_version:
+                _backup_plugin(plugin_id, target_path, old_version)
             shutil.rmtree(target_path)
-            
+
         shutil.move(str(source_path), str(target_path))
-        
+
         # 3. Persist plugin registry entry
         module_path = f"worker.plugins.third_party.{plugin_id}.plugin"
         # If plugin.py is missing, fall back to the package root module
@@ -307,7 +373,15 @@ async def confirm_install_plugin(token: str, current_user=Depends(require_admin)
         # Worker side
         await reload_system_plugins_task.kiq()
 
-        return {"status": "success", "message": f"Plugin {plugin_id} was installed successfully."}
+        # Build response message with upgrade information
+        if is_upgrade and old_version:
+            message = f"Plugin {plugin_id} upgraded from {old_version} to {new_version}."
+        elif old_version:
+            message = f"Plugin {plugin_id} reinstalled (version {new_version})."
+        else:
+            message = f"Plugin {plugin_id} installed successfully."
+
+        return {"status": "success", "message": message, "is_upgrade": is_upgrade}
 
     except ApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)


### PR DESCRIPTION
## Summary
为插件安装流程添加升级安全保障（版本比较、自动备份、日志记录），并更新插件开发指南。

## Plugin Upgrade Safety

### Version Comparison
- 添加语义版本比较（`_parse_version`, `_compare_versions`）
- 自动识别升级、降级、重装场景

### Automatic Backup
- 覆盖安装前自动备份旧插件到 `.backup/<plugin_id>_<version>_<timestamp>`
- 每个插件最多保留 3 个历史版本，自动清理最旧的

### Upgrade Logging
- `⬆️ Upgrading plugin {id}: {old} → {new}`
- `🔄 Reinstalling plugin {id}`
- `⬇️ Downgrading plugin {id}: {old} → {new}` (warning)

### API Response
- 返回 `is_upgrade` 标志和描述性消息

## Plugin Development Guide Updates

### Versioning Section
- 新增 SemVer 规范说明和 bump 时机参考表
- 记录框架升级行为（备份、热重载、用户数据保留）

### parse_single_item Best Practices
基于第三方插件开发中发现的常见问题，新增最佳实践：
- 始终调用平台 API 获取真实内容，不能仅从 URL 提取 ID
- 填充 `content_text` 以保证 AI 摘要质量
- 包含完整元数据（author、cover_url、published_at 等）
- API 调用加 try/except，失败时 fallback 到最小化数据
- 附正确示例和反模式示例

## Test Plan
- [ ] 首次安装新插件 → "installed successfully"，无备份
- [ ] 安装更高版本 → "upgraded from X to Y"，备份已创建
- [ ] 安装相同版本 → "reinstalled"，备份已创建
- [ ] 安装更低版本 → 日志中显示 downgrade warning
- [ ] 连续安装 4+ 版本 → 仅保留最近 3 个备份
- [ ] 升级后用户设置和 item 数据未丢失