### PR TITLE
fix: resolve hub startup crash due to wrong imports and missing type

### DIFF
--- a/worker/ingestion/pipeline.py
+++ b/worker/ingestion/pipeline.py
@@ -12,7 +12,7 @@ from worker.plugins.runtime import (
     close_plugin_context,
     fallback_text_for_summary,
 )
-from worker.plugins.manager import plugin_manager
+from shared.plugins.manager import plugin_manager
 
 class IngestionPipeline:
     def __init__(self):

--- a/worker/maintenance.py
+++ b/worker/maintenance.py
@@ -8,7 +8,6 @@ from shared.logger import worker_log
 from shared.config import ConfigManager, ConfigKeys
 from worker.plugins.pipeline import run_plugin_pipeline_task
 from worker.ingestion.pipeline import process_new_item_task
-from worker.plugins.manager import plugin_manager
 from shared.credentials import get_user_credential, validate_required_credentials
 from shared.plugins.manager import plugin_manager
 from shared.time_utils import get_app_timezone, now_in_app_timezone_naive

--- a/worker/plugins/pipeline.py
+++ b/worker/plugins/pipeline.py
@@ -1,3 +1,4 @@
+from typing import Any
 from shared.plugins.manager import plugin_manager
 from shared.entities import AIProcessingStatus, UniversalItem
 from hub.core.notifications import create_notification_for_user


### PR DESCRIPTION
Hub container was crashing on startup, causing 502 Bad Gateway and black screen in frontend.

Fixes:
- Fix import path: worker.plugins.manager -> shared.plugins.manager in worker/ingestion/pipeline.py
- Remove duplicate wrong import in worker/maintenance.py
- Add missing typing.Any import in worker/plugins/pipeline.py